### PR TITLE
Updated script to correctly generate CSR.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM alpine:3.13
+FROM alpine:3.17.2
 
 # This makes it easy to build tagged images with different `kubectl` versions.
-ARG KUBECTL_VERSION="v1.13.12"
+ARG KUBECTL_VERSION="v1.26.1"
 
 # Set by docker automatically
 ARG TARGETOS

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 DOCKER_IMAGE_NAME ?= newrelic/k8s-webhook-cert-manager
 DOCKER_IMAGE_TAG ?= latest
-KUBECTL_VERSION ?= v1.13.12
+KUBECTL_VERSION ?= v1.26.1
 
 
 .PHONY: all

--- a/e2e-tests/manifests/webhook.yaml
+++ b/e2e-tests/manifests/webhook.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: e2e-test-cert-manager-webhook

--- a/generate_certificate.sh
+++ b/generate_certificate.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Fully qualified name of the CSR object
-csr="certificatesigningrequests.v1beta1.certificates.k8s.io"
+csr="certificatesigningrequests"
 
 usage() {
   cat <<EOF
@@ -80,7 +80,7 @@ fi
 
 
 tmpdir=$(mktemp -d)
-echo "creating certs in tmpdir ${tmpdir} "
+echo "INFO: Creating certs in tmpdir ${tmpdir} "
 
 cat <<EOF >> "${tmpdir}/csr.conf"
 [req]
@@ -99,10 +99,10 @@ DNS.3 = ${fullServiceDomain}
 EOF
 
 openssl genrsa -out "${tmpdir}/server-key.pem" 2048
-openssl req -new -key "${tmpdir}/server-key.pem" -subj "/CN=${fullServiceDomain}" -out "${tmpdir}/server.csr" -config "${tmpdir}/csr.conf"
+openssl req -new -key "${tmpdir}/server-key.pem" -subj "/O=system:nodes/CN=system:node:${fullServiceDomain}" -out "${tmpdir}/server.csr" -config "${tmpdir}/csr.conf"
 
 csrName=${service}.${namespace}
-echo "creating csr: ${csrName} "
+echo "INFO: Creating csr: ${csrName} "
 set +e
 
 # clean-up any previously created CSR for our service. Ignore errors if not present.
@@ -124,6 +124,7 @@ spec:
   groups:
   - system:authenticated
   request: $(base64 < "${tmpdir}/server.csr" | tr -d '\n')
+  signerName: kubernetes.io/kubelet-serving
   usages:
   - digital signature
   - key encipherment

--- a/generate_certificate.sh
+++ b/generate_certificate.sh
@@ -116,7 +116,7 @@ set -e
 
 # create server cert/key CSR and send it to k8s api
 cat <<EOF | kubectl create --validate=false -f -
-apiVersion: certificates.k8s.io/v1beta1
+apiVersion: certificates.k8s.io/v1
 kind: CertificateSigningRequest
 metadata:
   name: ${csrName}


### PR DESCRIPTION
The `generate_certificate.sh` file needs to be updated to `v1` of the Certificate API, and the CSR updated so it will correctly generate on newer K8s versions. Also updated the `Dockerfile` to the latest `alpine` image version.