### PR TITLE
Updated release tag regex

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Generate docker image version from git tag
         run: |
-          echo "${{ github.event.release.tag_name }}" | grep -E '^v[0-9.]*[0-9]$'
+          echo "${{ github.event.release.tag_name }}" | grep -E '^v[0-9.]*[0-9]-?.*?$'
           DOCKER_IMAGE_TAG=$(echo "${{ github.event.release.tag_name }}" | sed 's/^v//')
           echo "DOCKER_IMAGE_TAG=$DOCKER_IMAGE_TAG" >> $GITHUB_ENV
 


### PR DESCRIPTION
Updated the regex used to validate the release tag on a GitHub release for pre-release RCs. 