### PR TITLE
Use `docker/build-push-action@v4` to push images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,22 +27,28 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - uses: docker/login-action@v2
+      - name: Login to docker
+        uses: docker/login-action@v2
         with:
           username: scopeci
           password: ${{ secrets.SCOPECI_TOKEN }}
 
       - name: Build and push docker image
-        run: |
-          docker buildx build --push --platform=$DOCKER_PLATFORMS \
-            -t $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_TAG \
-            .
-      - name: Push :latest image
-        if: ${{ ! github.event.release.prerelease }}
-        run: |
-          docker buildx build --push --platform=$DOCKER_PLATFORMS \
-            -t $DOCKER_IMAGE_NAME:latest \
-            .
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          platforms: ${{ env.DOCKER_PLATFORMS }}
+          push: true
+          tags: ${{ env.DOCKER_IMAGE_NAME }}:${{ env.DOCKER_IMAGE_TAG }}
+
+      - name: Push latest image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          platforms: ${{ env.DOCKER_PLATFORMS }}
+          push: ${{ ! github.event.release.prerelease }}
+          tags: ${{ env.DOCKER_IMAGE_NAME }}:latest


### PR DESCRIPTION
Ref: https://github.com/docker/build-push-action

@ricksalsa 
I tested the changes from this Pull Request on my fork. I was able to use following Github Action to push the docker image to Dockerhub.
You can see results here:
https://github.com/michalbiesek/k8s-webhook-cert-manager/actions/runs/4487943887
https://hub.docker.com/r/mbiesekcribl/k8s-webhook-cert-manager/tags
https://github.com/michalbiesek/k8s-webhook-cert-manager/releases/tag/v1.0.0-rc1

Just FYI: Besides changes from commit 6112591, on the reference links showing results I use the changes related to my creds (not included in this PR).