### PR TITLE
Fix `Lint and test code` GitHub Action

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -25,7 +25,7 @@ jobs:
           driver: docker
           start args: '--force'
       - name: Run e2e test
-        continue-on-error: 'true'
+        continue-on-error: true
         run: |
           # make minikube use local docker registry
           eval $(minikube -p minikube docker-env)


### PR DESCRIPTION
- `continue-on-error` supports `true` and `false` values without backtick

Ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error

See error workflow here: 
https://github.com/criblio/k8s-webhook-cert-manager/actions/runs/4572818414