### PR TITLE
Bump Alpine docker image `3.17.2` -> `3.17.3`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.2
+FROM alpine:3.17.3
 
 # This makes it easy to build tagged images with different `kubectl` versions.
 ARG KUBECTL_VERSION="v1.26.1"


### PR DESCRIPTION
Ref: https://www.alpinelinux.org/posts/Alpine-3.17.3-released.html